### PR TITLE
Spring Boot Dependencies 4.0.0-M1 to 4.0.0-M2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,8 @@
     </scm>
     <properties>
         <!-- == Depends terasoluna-server, terasolune-batch == -->
-        <org.springframework.boot.version>4.0.0-M1</org.springframework.boot.version>
-        <org.springframework.version>7.0.0-M7</org.springframework.version>
+        <org.springframework.boot.version>4.0.0-M2</org.springframework.boot.version>
+        <org.springframework.version>7.0.0-M8</org.springframework.version>
         <org.mybatis.version>3.5.17</org.mybatis.version>
         <org.mybatis.spring.version>3.0.4</org.mybatis.spring.version>
         <mapstruct.version>1.6.3</mapstruct.version>


### PR DESCRIPTION
update spring boot dependencies to 4.0.0-M2.

relates to [TSF4J5-6976](https://terasolunaorg.atlassian.net/browse/TSF4J5-6976).