### PR TITLE
Spring Boot 4.0.0 to 4.0.1. TSF4J5-7492

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     </scm>
     <properties>
         <!-- == Depends terasoluna-server, terasolune-batch == -->
-        <org.springframework.boot.version>4.0.0</org.springframework.boot.version>
+        <org.springframework.boot.version>4.0.1</org.springframework.boot.version>
         <org.mybatis.version>3.5.17</org.mybatis.version>
         <org.mybatis.spring.version>3.0.4</org.mybatis.spring.version>
         <mapstruct.version>1.6.3</mapstruct.version>


### PR DESCRIPTION
update spring boot dependencies to 4.0.1.

relates to [TSF4J5-7492](https://terasolunaorg.atlassian.net/browse/TSF4J5-7492).