### PR TITLE
[2.0.x] Upgrade ojdbc for 26ai. TSF4J5-7717

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <jakarta-el-api.version>5.0.1</jakarta-el-api.version>
         <commons-io.version>2.20.0</commons-io.version>
         <com.sun.xml.bind.version>4.0.6</com.sun.xml.bind.version>
-        <ojdbc.version>23.9.0.25.07</ojdbc.version>
+        <ojdbc.version>23.26.0.0.0</ojdbc.version>
         <postgresql.version>42.7.8</postgresql.version>
 
         <!-- == Depends only terasoluna-server == -->


### PR DESCRIPTION
We have upgraded the OJdbc version for 26ai.

relates to [TSF4J5-7717](https://terasolunaorg.atlassian.net/browse/TSF4J5-7717).